### PR TITLE
Create and use SLPError enum

### DIFF
--- a/lib/rslp.rb
+++ b/lib/rslp.rb
@@ -30,7 +30,7 @@ module OpenSLP
     # machine's locale.
     #
     # The +async+ argument may be set to true or false and establishes whether
-    # the underlying handle is set to handl asynchronous operations or not. By
+    # the underlying handle is set to handle asynchronous operations or not. By
     # default this value is false.
     #
     # If a block is given, then the object itself is yielded to the block, and

--- a/lib/rslp.rb
+++ b/lib/rslp.rb
@@ -11,7 +11,10 @@ module OpenSLP
     extend OpenSLP::Functions
 
     # The version of the rslp library.
-    VERSION = '0.0.1'.freeze
+    VERSION = '0.0.2'.freeze
+
+    # Internal error raised whenever an openslp function fails.
+    class Error < StandardError; end
 
     # The language tag for requests.
     attr_reader :lang
@@ -49,9 +52,8 @@ module OpenSLP
 
       ptr = FFI::MemoryPointer.new(:ulong)
 
-      if SLPOpen(lang, async, ptr) != SLP_OK
-        raise SystemCallError.new('SLPOpen', FFI.errno)
-      end
+      result = SLPOpen(lang, async, ptr)
+      raise Error, "SLPOpen(): #{result}" if result != :SLP_OK
 
       @handle = ptr.read_ulong
 
@@ -109,7 +111,7 @@ module OpenSLP
         cookie
       )
 
-      raise SystemCallError.new('SLPReg', result) if result != SLP_OK
+      raise Error, "SLPReg(): #{result}" if result != :SLP_OK
 
       options[:url]
     end
@@ -122,7 +124,7 @@ module OpenSLP
       cookie = FFI::MemoryPointer.new(:void)
 
       result = SLPDereg(@handle, url, callback, cookie)
-      raise SystemCallError.new('SLPDereg', result) if result != SLP_OK
+      raise Error, "SLPDereg(): #{result}" if result != :SLP_OK
 
       true
     end
@@ -138,7 +140,7 @@ module OpenSLP
       cookie = FFI::MemoryPointer.new(:void)
 
       result = SLPDelAttrs(@handle, url, attributes, callback, cookie)
-      raise SystemCallError.new('SLPDelAttrs', result) if result != SLP_OK
+      raise Error, "SLPDelAttrs(): #{result}" if result != :SLP_OK
 
       attributes
     end
@@ -150,11 +152,8 @@ module OpenSLP
       begin
         pptr = FFI::MemoryPointer.new(:pointer, 128)
 
-        rv = SLPFindScopes(@handle, pptr)
-
-        if rv != SLP_OK
-          raise SystemCallError.new('SLPFindScopes', rv)
-        end
+        result = SLPFindScopes(@handle, pptr)
+        raise Error, "SLPFindScopes(): #{result}" if result != :SLP_OK
 
         arr = pptr.read_array_of_string
       ensure
@@ -191,11 +190,8 @@ module OpenSLP
 
       cookie = FFI::MemoryPointer.new(:void)
 
-      rv = SLPFindSrvs(@handle, type, scope, filter, callback, cookie)
-
-      if rv != SLP_OK
-        raise SystemCallError.new('SLPFindSrvs', rv)
-      end
+      result = SLPFindSrvs(@handle, type, scope, filter, callback, cookie)
+      raise Error, "SLPFindSrvs(): #{result}" if result != :SLP_OK
 
       arr
     end
@@ -225,11 +221,8 @@ module OpenSLP
 
       cookie = FFI::MemoryPointer.new(:void)
 
-      rv = SLPFindSrvTypes(@handle, auth, scope, callback, cookie)
-
-      if rv != SLP_OK
-        raise SystemCallError.new('SLPFindSrvs', rv)
-      end
+      result = SLPFindSrvTypes(@handle, auth, scope, callback, cookie)
+      raise Error, "SLPFindSrvs(): #{result}" if result != :SLP_OK
 
       arr
     end
@@ -253,11 +246,8 @@ module OpenSLP
 
       cookie = FFI::MemoryPointer.new(:void)
 
-      rv = SLPFindAttrs(@handle, url, scope, attrs, callback, cookie)
-
-      if rv != SLP_OK
-        raise SystemCallError.new('SLPFindSrvs', rv)
-      end
+      result = SLPFindAttrs(@handle, url, scope, attrs, callback, cookie)
+      raise Error, "SLPFindAttrs(): #{result}" if result != :SLP_OK
 
       arr
     end
@@ -292,9 +282,8 @@ module OpenSLP
       begin
         pptr = FFI::MemoryPointer.new(SLPSrvURL)
 
-        if SLPParseSrvURL(url, pptr) != SLP_OK
-          raise SystemCallError.new('SLPParseSrvURL', FFI.errno)
-        end
+        result = SLPParseSrvURL(url, pptr)
+        raise Error, "SLPParseSrvURL(): #{result}" if result != :SLP_OK
 
         ptr = pptr.read_pointer
         struct = SLPSrvURL.new(ptr)
@@ -312,9 +301,8 @@ module OpenSLP
       begin
         pptr = FFI::MemoryPointer.new(:pointer)
 
-        if SLPEscape(string, pptr, istag) != SLP_OK
-          raise SystemCallError.new('SLPEscape', FFI.errno)
-        end
+        result = SLPEscape(string, pptr, istag)
+        raise Error, "SLPEscape(): #{result}" if result != :SLP_OK
 
         str = pptr.read_pointer.read_string
       ensure
@@ -331,9 +319,8 @@ module OpenSLP
       begin
         pptr = FFI::MemoryPointer.new(:pointer)
 
-        if SLPUnescape(string, pptr, istag) != SLP_OK
-          raise SystemCallError.new('SLPEscape', FFI.errno)
-        end
+        result = SLPUnescape(string, pptr, istag)
+        raise Error, "SLPUnescape(): #{result}" if result != :SLP_OK
 
         str = pptr.read_pointer.read_string
       ensure

--- a/lib/slp/functions.rb
+++ b/lib/slp/functions.rb
@@ -19,6 +19,29 @@ module OpenSLP
       end
     end
 
+    SLPError = enum(
+      :SLP_LAST_CALL, 1,
+      :SLP_OK, 0,
+      :SLP_LANGUAGE_NOT_SUPPORTED, -1,
+      :SLP_PARSE_ERROR, -2,
+      :SLP_INVALID_REGISTRATION, -3,
+      :SLP_SCOPE_NOT_SUPPORTED, -4,
+      :SLP_AUTHENTICATION_ABSENT, -6,
+      :SLP_AUTHENTICATION_FAILED, -7,
+      :SLP_INVALID_UPDATE, -13,
+      :SLP_REFRESH_REJECTED, -15,
+      :SLP_NOT_IMPLEMENTED, -17,
+      :SLP_BUFFER_OVERFLOW, -18,
+      :SLP_NETWORK_TIMED_OUT, -19,
+      :SLP_NETWORK_INIT_FAILED, -20,
+      :SLP_MEMORY_ALLOC_FAILED, -21,
+      :SLP_PARAMETER_BAD, -22,
+      :SLP_NETWORK_ERROR, -23,
+      :SLP_INTERNAL_SYSTEM_ERROR, -24,
+      :SLP_HANDLE_IN_USE, -25,
+      :SLP_TYPE_ERROR, -26
+    )
+
     typedef :ulong, :handle
 
     callback :SLPSrvURLCallback, [:handle, :string, :ushort, :int, :pointer], :bool
@@ -27,28 +50,31 @@ module OpenSLP
     callback :SLPRegReportCallback, [:handle, :int, :pointer], :void
 
     attach_function :SLPClose, [:handle], :void
-    attach_function :SLPEscape, [:string, :pointer, :bool], :int
-    attach_function :SLPDelAttrs, [:handle, :string, :string, :SLPRegReportCallback, :pointer], :int
-    attach_function :SLPDereg, [:handle, :string, :SLPRegReportCallback, :pointer], :int
+    attach_function :SLPEscape, [:string, :pointer, :bool], SLPError
+    attach_function :SLPDelAttrs, [:handle, :string, :string, :SLPRegReportCallback, :pointer], SLPError
+    attach_function :SLPDereg, [:handle, :string, :SLPRegReportCallback, :pointer], SLPError
 
     attach_function :SLPFindAttrs,
-      [:handle, :string, :string, :string, :SLPAttrCallback, :pointer], :int
+      [:handle, :string, :string, :string, :SLPAttrCallback, :pointer], SLPError
 
-    attach_function :SLPFindScopes, [:handle, :pointer], :int
+    attach_function :SLPFindScopes, [:handle, :pointer], SLPError
 
     attach_function :SLPFindSrvs,
-      [:handle, :string, :string, :string, :SLPSrvURLCallback, :pointer], :int
+      [:handle, :string, :string, :string, :SLPSrvURLCallback, :pointer], SLPError
 
     attach_function :SLPFindSrvTypes,
-      [:handle, :string, :string, :SLPSrvTypeCallback, :pointer], :int
+      [:handle, :string, :string, :SLPSrvTypeCallback, :pointer], SLPError
 
     attach_function :SLPFree, [:pointer], :void
     attach_function :SLPGetProperty, [:string], :string
     attach_function :SLPGetRefreshInterval, [], :uint
-    attach_function :SLPOpen, [:string, :bool, :pointer], :handle
-    attach_function :SLPParseSrvURL, [:string, :pointer], :int
-    attach_function :SLPReg, [:handle, :string, :ushort, :string, :string, :bool, :SLPRegReportCallback, :pointer], :int
+    attach_function :SLPOpen, [:string, :bool, :pointer], SLPError
+    attach_function :SLPParseSrvURL, [:string, :pointer], SLPError
+
+    attach_function :SLPReg,
+      [:handle, :string, :ushort, :string, :string, :bool, :SLPRegReportCallback, :pointer], SLPError
+
     attach_function :SLPSetProperty, [:string, :string], :void
-    attach_function :SLPUnescape, [:string, :pointer, :bool], :int
+    attach_function :SLPUnescape, [:string, :pointer, :bool], SLPError
   end
 end

--- a/spec/rslp_spec.rb
+++ b/spec/rslp_spec.rb
@@ -14,7 +14,7 @@ describe OpenSLP::SLP do
 
   context "version" do
     example "version is set to the expected value" do
-      expect(OpenSLP::SLP::VERSION).to eq('0.0.1')
+      expect(OpenSLP::SLP::VERSION).to eq('0.0.2')
     end
   end
 

--- a/spec/rslp_spec.rb
+++ b/spec/rslp_spec.rb
@@ -6,7 +6,7 @@
 require 'rspec'
 require 'rslp'
 
-describe OpenSLP::SLP do
+RSpec.describe OpenSLP::SLP do
   before do
     @lang = 'en-us'
     @slp = OpenSLP::SLP.new(@lang, false)


### PR DESCRIPTION
This PR updates the code so that the various functions return an actual `SLPError` enum rather than a plain int. This lines up with the API.

I also updated the code so that errors raise an `OpenSLP::SLP::Error` instead of a `SystemCallError`, and improved the error message.