### PR TITLE
Fix parse_service_url

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,2 +1,11 @@
+## 0.0.2 - ???
+* Fixed the parse_service_url singleton method. The underlying SLPSrvURL
+  struct is now a managed struct.
+* Added some nicer method aliases to the SLPSrvURL struct.
+* Refactored the underlying C function wrappers to return an SLPError enum
+  to more closely align with the API.
+* Any internal function failures now raise an OpenSLP::SLP::Error instead
+  of a SystemCallError. The error message has also been improved.
+
 ## 0.0.1 - 2-Jul-2021
 * Initial release

--- a/lib/rslp.rb
+++ b/lib/rslp.rb
@@ -288,7 +288,7 @@ module OpenSLP
         ptr = pptr.read_pointer
         struct = SLPSrvURL.new(ptr)
       ensure
-        SLPFree(ptr)
+        pptr.free unless pptr.null?
       end
 
       struct

--- a/lib/slp/structs.rb
+++ b/lib/slp/structs.rb
@@ -1,8 +1,10 @@
-require 'ffi'
+require_relative 'functions'
 
 module OpenSLP
   module Structs
-    class SLPSrvURL < FFI::Struct
+    class SLPSrvURL < FFI::ManagedStruct
+      extend OpenSLP::Functions
+
       layout(
         :s_pcSrvType, :string,
         :s_pcHost, :string,
@@ -10,6 +12,30 @@ module OpenSLP
         :s_pcNetFamily, :string,
         :s_pcSrvPart, :string
       )
+
+      def self.release(pointer)
+        SLPFree(pointer) unless pointer.null?
+      end
+
+      def service_type
+        self[:s_pcSrvType]
+      end
+
+      def host
+        self[:s_pcHost]
+      end
+
+      def port
+        self[:s_iPort]
+      end
+
+      def net_family
+        self[:s_pcNetFamily]
+      end
+
+      def url_remainder
+        self[:s_pcSrvPart]
+      end
     end
   end
 end

--- a/spec/rslp_spec.rb
+++ b/spec/rslp_spec.rb
@@ -33,13 +33,15 @@ RSpec.describe OpenSLP::SLP do
     end
   end
 
-  context "singleton methods" do
-    example "defines a refresh_interval method" do
-      expect(described_class).to respond_to(:refresh_interval)
-    end
+  describe "singleton methods" do
+    context "refresh_interval" do
+      example "defines a refresh_interval method" do
+        expect(described_class).to respond_to(:refresh_interval)
+      end
 
-    example "returns the expected value for refresh_interval" do
-      expect(described_class.refresh_interval).to eq(0)
+      example "returns the expected value for refresh_interval" do
+        expect(described_class.refresh_interval).to eq(0)
+      end
     end
 
     example "defines a get_property method" do
@@ -50,7 +52,7 @@ RSpec.describe OpenSLP::SLP do
       expect(described_class).to respond_to(:set_property)
     end
 
-    describe "parse_service_url" do
+    context "parse_service_url" do
       let(:valid_url) { "service:test.openslp://192.168.100.1:3003,en,65535" }
 
       before do
@@ -86,17 +88,26 @@ RSpec.describe OpenSLP::SLP do
       end
     end
 
-    example "defines a escape_reserved method" do
-      expect(described_class).to respond_to(:escape_reserved)
+    context "escape_reserved" do
+      example "defines a escape_reserved method" do
+        expect(described_class).to respond_to(:escape_reserved)
+      end
+
+      example "returns the expected value for the escape_reserved method" do
+        expected = "\\2Ctag-example\\2C"
+        expect(described_class.escape_reserved(",tag-example,")).to eq(expected)
+      end
     end
 
-    example "returns the expected value for the escape_reserved method" do
-      expected = "\\2Ctag-example\\2C"
-      expect(described_class.escape_reserved(",tag-example,")).to eq(expected)
-    end
+    context "unescape_reserved" do
+      example "defines a unescape_reserved method" do
+        expect(described_class).to respond_to(:unescape_reserved)
+      end
 
-    example "defines a unescape_reserved method" do
-      expect(described_class).to respond_to(:unescape_reserved)
+      example "returns the expected value for the unescape_reserved method" do
+        expected = ",tag-example,"
+        expect(described_class.unescape_reserved("\\2Ctag-example\\2C")).to eq(expected)
+      end
     end
   end
 

--- a/spec/rslp_spec.rb
+++ b/spec/rslp_spec.rb
@@ -9,22 +9,22 @@ require 'rslp'
 RSpec.describe OpenSLP::SLP do
   before do
     @lang = 'en-us'
-    @slp = OpenSLP::SLP.new(@lang, false)
+    @slp = described_class.new(@lang, false)
   end
 
   context "version" do
     example "version is set to the expected value" do
-      expect(OpenSLP::SLP::VERSION).to eq('0.0.2')
+      expect(described_class::VERSION).to eq('0.0.2')
     end
   end
 
   context "constructor" do
     example "defaults to an empty string if no lang is provided" do
-      expect(OpenSLP::SLP.new.lang).to eq('')
+      expect(described_class.new.lang).to eq('')
     end
 
     example "defaults to a false async value if no value is provided" do
-      expect(OpenSLP::SLP.new.async).to be false
+      expect(described_class.new.async).to be false
     end
 
     example "sets attributes to expected values" do
@@ -35,36 +35,68 @@ RSpec.describe OpenSLP::SLP do
 
   context "singleton methods" do
     example "defines a refresh_interval method" do
-      expect(OpenSLP::SLP).to respond_to(:refresh_interval)
+      expect(described_class).to respond_to(:refresh_interval)
     end
 
     example "returns the expected value for refresh_interval" do
-      expect(OpenSLP::SLP.refresh_interval).to eq(0)
+      expect(described_class.refresh_interval).to eq(0)
     end
 
     example "defines a get_property method" do
-      expect(OpenSLP::SLP).to respond_to(:get_property)
+      expect(described_class).to respond_to(:get_property)
     end
 
     example "defines a set_property method" do
-      expect(OpenSLP::SLP).to respond_to(:set_property)
+      expect(described_class).to respond_to(:set_property)
     end
 
-    example "defines a parse_service_url method" do
-      expect(OpenSLP::SLP).to respond_to(:parse_service_url)
+    describe "parse_service_url" do
+      let(:valid_url) { "service:test.openslp://192.168.100.1:3003,en,65535" }
+
+      before do
+        @struct = described_class.parse_service_url(valid_url)
+      end
+
+      example "defines a parse_service_url method" do
+        expect(described_class).to respond_to(:parse_service_url)
+      end
+
+      example "does not raise an error if the url is valid" do
+        expect{ described_class.parse_service_url(valid_url) }.not_to raise_error
+      end
+
+      example "returns a struct with the expected service type" do
+        expect(@struct.service_type).to eq("service:test.openslp")
+      end
+
+      example "returns a struct with the expected host" do
+        expect(@struct.host).to eq("192.168.100.1")
+      end
+
+      example "returns a struct with the expected port" do
+        expect(@struct.port).to eq(3003)
+      end
+
+      example "returns a struct with the expected net family" do
+        expect(@struct.net_family).to eq("")
+      end
+
+      example "returns a struct with the expected url remainder" do
+        expect(@struct.url_remainder).to eq("")
+      end
     end
 
     example "defines a escape_reserved method" do
-      expect(OpenSLP::SLP).to respond_to(:escape_reserved)
+      expect(described_class).to respond_to(:escape_reserved)
     end
 
     example "returns the expected value for the escape_reserved method" do
       expected = "\\2Ctag-example\\2C"
-      expect(OpenSLP::SLP.escape_reserved(",tag-example,")).to eq(expected)
+      expect(described_class.escape_reserved(",tag-example,")).to eq(expected)
     end
 
     example "defines a unescape_reserved method" do
-      expect(OpenSLP::SLP).to respond_to(:unescape_reserved)
+      expect(described_class).to respond_to(:unescape_reserved)
     end
   end
 


### PR DESCRIPTION
Currently the `parse_service_url` singleton method segfaults because we aren't managing the memory properly. This PR converts the `SLPSrvURL` struct into a managed struct that frees itself properly via the `release` interface.

I also added some handy methods to the struct, as well as some specs.