### PR TITLE
Add more specs and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ None that I'm aware of. Please report bugs on the project page at:
 
 https://github.com/djberg96/rslp
 
+## Running the Specs
+You will need an OpenSLP server running on localhost to run all of the specs.
+The easiest way to do that is to install docker and run:
+
+  `docker run -d -p 427:427/tcp -p 427:427/udp vcrhonek/openslp`
+
+Once you're done just terminate the container.
+
 ## Future Plans
 None at this time.
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ The easiest way to do that is to install docker and run:
 
 Once you're done just terminate the container.
 
+## Notes
+Also see Novell's SLP implementation.
+
 ## Future Plans
 None at this time.
 

--- a/lib/rslp.rb
+++ b/lib/rslp.rb
@@ -31,7 +31,7 @@ module OpenSLP
     #
     # The +async+ argument may be set to true or false and establishes whether
     # the underlying handle is set to handle asynchronous operations or not. By
-    # default this value is false.
+    # default this value is false, and may not be supported by your implementation.
     #
     # The +host+ argument, if present, will associate the Host/IP with the OpenSLP
     # handle. This is the Hostname/IP address of the Service Agent / Directory Agent

--- a/lib/rslp.rb
+++ b/lib/rslp.rb
@@ -163,6 +163,10 @@ module OpenSLP
     #
     # Returns the list of deleted attributes if successful.
     #
+    # Note that this method may not be supported. In that case, the only way
+    # to alter a service's attributes is to deregister it then register it
+    # again without the undesired attributes.
+    #
     def delete_service_attributes(url, attributes)
       callback = Proc.new{ |hslp, err, cookie| }
 

--- a/lib/rslp.rb
+++ b/lib/rslp.rb
@@ -208,8 +208,8 @@ module OpenSLP
     # form of an LDAP search filter. The default is an empty string, which
     # will gather all services of the requested type.
     #
-    # The result is an array of hashes, with the URL as the key and its lifetime
-    # as the value.
+    # The result is an array of hashes, with the URL as the key and its
+    # remaining lifetime as the value.
     #
     def find_services(type, scope = '', filter = '')
       arr = []

--- a/lib/rslp.rb
+++ b/lib/rslp.rb
@@ -104,6 +104,8 @@ module OpenSLP
     # Returns the url if successful.
     #
     def register(options = {})
+      url = options.fetch(:url){ raise ArgumentError, ":url must be provided" }
+
       options[:lifetime] ||= SLP_LIFETIME_DEFAULT
       options[:attributes] ||= ""
       options[:fresh] ||= true
@@ -121,7 +123,7 @@ module OpenSLP
 
         result = SLPReg(
           @handle,
-          options[:url],
+          url,
           options[:lifetime],
           nil,
           attributes,
@@ -135,7 +137,7 @@ module OpenSLP
         cookie.free unless cookie.null?
       end
 
-      options[:url]
+      url
     end
 
     # Deregisters the advertisement for +url+ in all scopes where the service

--- a/spec/rslp_spec.rb
+++ b/spec/rslp_spec.rb
@@ -192,6 +192,18 @@ RSpec.describe OpenSLP::SLP do
 =end
     end
 
+    context "find_service_types" do
+      example "has a find_services method" do
+        expect(@slp).to respond_to(:find_service_types)
+      end
+
+      example "the find_service_types method returns the expected results" do
+        results = @slp.find_service_types
+        expect(results).to be_kind_of(Array)
+        expect(results.first).to eq(service)
+      end
+    end
+
     context "registration" do
       example "registers a service successfully if url is provided" do
         expect(@slp.register(url: url)).to eq(url)

--- a/spec/rslp_spec.rb
+++ b/spec/rslp_spec.rb
@@ -128,9 +128,10 @@ RSpec.describe OpenSLP::SLP do
         expect(@slp.register(url: url)).to eq(url)
       end
 
-      example "accepts hash attributes option" do
+      example "accepts hash attributes option and registers them as expected" do
         expect(@slp.register(url: url, attributes: attributes)).to eq(url)
-        #expect(@slp.find_service_attributes(url, "foo=hello")).to eq(attributes)
+        expect(@slp.find_service_attributes(url, "foo")).to eq(["(foo=hello)"])
+        expect(@slp.find_service_attributes(url, "foo,bar")).to eq(["(foo=hello),(bar=world)"])
       end
 
       example "raises an error if the :url option is not provided" do

--- a/spec/rslp_spec.rb
+++ b/spec/rslp_spec.rb
@@ -111,6 +111,48 @@ RSpec.describe OpenSLP::SLP do
     end
   end
 
+  describe "registration and deregistration" do
+    let(:url){ "service:ntp://time.windows.com" }
+    let(:attributes){ {"foo" => "hello", "bar" => "world"} }
+
+    before do
+      @slp = OpenSLP::SLP.new(host: 'localhost')
+    end
+
+    context "registration" do
+      example "registers a service successfully if url is provided" do
+        expect(@slp.register(url: url)).to eq(url)
+      end
+
+      example "doesn't matter if service is already registered" do
+        expect(@slp.register(url: url)).to eq(url)
+      end
+
+      example "accepts hash attributes option" do
+        expect(@slp.register(url: url, attributes: attributes)).to eq(url)
+        #expect(@slp.find_service_attributes(url, "foo=hello")).to eq(attributes)
+      end
+
+      example "raises an error if the :url option is not provided" do
+        expect{ @slp.register }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "deregistration" do
+      example "deregisters a service successfully if it exists" do
+        expect(@slp.deregister(url)).to eq(url)
+      end
+
+      example "fails to deregister a service successfully if it does not exist" do
+        expect{ @slp.deregister('bogus') }.to raise_error(OpenSLP::SLP::Error)
+      end
+    end
+
+    after do
+      @slp.close
+    end
+  end
+
   after do
     @slp.close if @slp
     @slp = nil

--- a/spec/rslp_spec.rb
+++ b/spec/rslp_spec.rb
@@ -1,8 +1,14 @@
-########################################################################
+##############################################################################
 # rslp_spec.rb
 #
-# Test suite for the rslp library.
-########################################################################
+# Test suite for the rslp library. Note that these specs assume that you
+# have an OpenSLP server running on localhost. If not, install Docker and
+# run the following command:
+#
+#   docker run -d -p 427:427/tcp -p 427:427/udp vcrhonek/openslp
+#
+# Once complete, simply stop the docker container and delete the image.
+##############################################################################
 require 'rspec'
 require 'rslp'
 

--- a/spec/rslp_spec.rb
+++ b/spec/rslp_spec.rb
@@ -115,10 +115,17 @@ RSpec.describe OpenSLP::SLP do
         expect(described_class.unescape_reserved("\\2Ctag-example\\2C")).to eq(expected)
       end
     end
+
+    context "set_app_property_file" do
+      example "defines a set_app_property_file method" do
+        expect(described_class).to respond_to(:set_app_property_file)
+      end
+    end
   end
 
   describe "instance methods" do
-    let(:url){ "service:ntp://time.windows.com" }
+    let(:service){ "service:ntp" }
+    let(:url){ "#{service}://time.windows.com" }
     let(:attributes){ {"foo" => "hello", "bar" => "world"} }
 
     context "close" do
@@ -130,6 +137,40 @@ RSpec.describe OpenSLP::SLP do
       example "calling close multiple times has no effect" do
         expect(@slp.close).to be_nil
         expect(@slp.close).to be_nil
+      end
+    end
+
+    context "find_scopes" do
+      example "has a find_scopes method" do
+        expect(@slp).to respond_to(:find_scopes)
+      end
+
+      example "the find_scopes method returns the expected value" do
+        expect(@slp.find_scopes).to eq(['DEFAULT'])
+      end
+    end
+
+    context "find_services" do
+      example "has a find_services method" do
+        expect(@slp).to respond_to(:find_services)
+      end
+
+      example "the find_services method returns the expected types" do
+        results = @slp.find_services(service)
+        expect(results).to be_kind_of(Array)
+        expect(results.first).to be_kind_of(Hash)
+      end
+
+      example "the find_services method returns the expected values" do
+        results = @slp.find_services(service)
+        expect(results.first.keys).to include(url)
+        expect(results.first.values.first).to be_kind_of(Numeric)
+      end
+
+      example "the find_services method with scope returns the expected values" do
+        results = @slp.find_services(service)
+        expect(results.first.keys).to include(url)
+        expect(results.first.values.first).to be_kind_of(Numeric)
       end
     end
 
@@ -148,6 +189,11 @@ RSpec.describe OpenSLP::SLP do
 
       example "raises an error if the :url option is not provided" do
         expect{ @slp.register }.to raise_error(ArgumentError, ":url must be provided")
+      end
+
+      example "registers a service successfully with a lifetime value" do
+        expect(@slp.register(url: url, lifetime: OpenSLP::SLP::SLP_LIFETIME_MAXIMUM)).to eq(url)
+        expect(@slp.find_services(service).first.values.first).to be_within(1).of(OpenSLP::SLP::SLP_LIFETIME_MAXIMUM)
       end
     end
 

--- a/spec/rslp_spec.rb
+++ b/spec/rslp_spec.rb
@@ -121,10 +121,6 @@ RSpec.describe OpenSLP::SLP do
     let(:url){ "service:ntp://time.windows.com" }
     let(:attributes){ {"foo" => "hello", "bar" => "world"} }
 
-    before do
-      @slp = OpenSLP::SLP.new(host: 'localhost')
-    end
-
     context "registration" do
       example "registers a service successfully if url is provided" do
         expect(@slp.register(url: url)).to eq(url)
@@ -141,7 +137,7 @@ RSpec.describe OpenSLP::SLP do
       end
 
       example "raises an error if the :url option is not provided" do
-        expect{ @slp.register }.to raise_error(ArgumentError)
+        expect{ @slp.register }.to raise_error(ArgumentError, ":url must be provided")
       end
     end
 
@@ -153,10 +149,6 @@ RSpec.describe OpenSLP::SLP do
       example "fails to deregister a service successfully if it does not exist" do
         expect{ @slp.deregister('bogus') }.to raise_error(OpenSLP::SLP::Error)
       end
-    end
-
-    after do
-      @slp.close
     end
   end
 

--- a/spec/rslp_spec.rb
+++ b/spec/rslp_spec.rb
@@ -144,8 +144,6 @@ RSpec.describe OpenSLP::SLP do
 
       example "accepts hash attributes option and registers them as expected" do
         expect(@slp.register(url: url, attributes: attributes)).to eq(url)
-        expect(@slp.find_service_attributes(url, "foo")).to eq(["(foo=hello)"])
-        expect(@slp.find_service_attributes(url, "foo,bar")).to eq(["(foo=hello),(bar=world)"])
       end
 
       example "raises an error if the :url option is not provided" do
@@ -160,6 +158,22 @@ RSpec.describe OpenSLP::SLP do
 
       example "fails to deregister a service successfully if it does not exist" do
         expect{ @slp.deregister('bogus') }.to raise_error(OpenSLP::SLP::Error)
+      end
+    end
+
+    context "find service attributes" do
+      before do
+        @slp.register(url: url, attributes: attributes)
+      end
+
+      example "successfully finds service attribute when they exist" do
+        expect(@slp.find_service_attributes(url)).to eq(["(foo=hello),(bar=world)"])
+        expect(@slp.find_service_attributes(url, "foo")).to eq(["(foo=hello)"])
+        expect(@slp.find_service_attributes(url, "foo,bar")).to eq(["(foo=hello),(bar=world)"])
+      end
+
+      example "returns an empty array if the service attribute does not exist" do
+        expect(@slp.find_service_attributes(url, "bogus")).to eq([])
       end
     end
   end

--- a/spec/rslp_spec.rb
+++ b/spec/rslp_spec.rb
@@ -117,9 +117,21 @@ RSpec.describe OpenSLP::SLP do
     end
   end
 
-  describe "registration and deregistration" do
+  describe "instance methods" do
     let(:url){ "service:ntp://time.windows.com" }
     let(:attributes){ {"foo" => "hello", "bar" => "world"} }
+
+    context "close" do
+      example "has a close method that returns the expected value" do
+        expect(@slp).to respond_to(:close)
+        expect(@slp.close).to be_nil
+      end
+
+      example "calling close multiple times has no effect" do
+        expect(@slp.close).to be_nil
+        expect(@slp.close).to be_nil
+      end
+    end
 
     context "registration" do
       example "registers a service successfully if url is provided" do

--- a/spec/rslp_spec.rb
+++ b/spec/rslp_spec.rb
@@ -151,6 +151,11 @@ RSpec.describe OpenSLP::SLP do
     end
 
     context "find_services" do
+      before do
+        sleep 1
+        @slp.register(url: url, attributes: attributes)
+      end
+
       example "has a find_services method" do
         expect(@slp).to respond_to(:find_services)
       end
@@ -167,11 +172,24 @@ RSpec.describe OpenSLP::SLP do
         expect(results.first.values.first).to be_kind_of(Numeric)
       end
 
-      example "the find_services method with scope returns the expected values" do
-        results = @slp.find_services(service)
+      example "the find_services method with valid scope returns the expected values" do
+        results = @slp.find_services(service, 'DEFAULT')
         expect(results.first.keys).to include(url)
         expect(results.first.values.first).to be_kind_of(Numeric)
       end
+
+=begin
+      # These specs appear to cause a segfault in the OpenSLP daemon.
+      example "the find_services method with invalid scope returns an empty value" do
+        results = @slp.find_services(service, 'bogus')
+        expect(results).to be_empty
+      end
+
+      example "the find_services method with filter on existing attribute returns the expected values" do
+        results = @slp.find_services(service, '', "(foo=hello)")
+        expect(results).to eq(1)
+      end
+=end
     end
 
     context "registration" do
@@ -200,6 +218,7 @@ RSpec.describe OpenSLP::SLP do
     context "deregistration" do
       example "deregisters a service successfully if it exists" do
         expect(@slp.deregister(url)).to eq(url)
+        expect(@slp.find_services(url)).to be_empty
       end
 
       example "fails to deregister a service successfully if it does not exist" do


### PR DESCRIPTION
This adds many more specs and updates the documentation.

Specifically, it explains how to run the specs locally if you don't already have an slpd running. It also notes which methods may not be supported.

There was one API tweak, which was to mandate the presence of the `:url` option for the `:register` method. This was always mandatory, it just wasn't enforced previously.